### PR TITLE
Add opik

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ with Large Language Models.
 - [Vercel Ai Playground](https://play.vercel.ai): One prompt, multiple Models (including GPT-4).
 - [Conju.ai](https://app.conju.ai/): A visual prompt chaining app.
 - [Voiceflow](https://www.voiceflow.com): Professional collaborative visual prompt-chaining tool.
-- [CometLLM](https://github.com/comet-ml/comet-llm): Track, visualize, and evaluate your LLM prompts and chains in one simple-to-use, convenient UI.
+- [Opik](https://github.com/comet-ml/opik): Evaluate, test, and ship LLM applications across your dev and production lifecycles.
 
 ## Prompt Generators
 


### PR DESCRIPTION
Comet recently sunset CometLLM and in its place launched Opik, a tool with most of the same capabilities as the old CometLLM but with a whole host of additional features and capabilities. This PR updates the readme accordingly.

Signed-off-by: Abby Morgan abigailm@comet.com