### PR TITLE
Add Rival

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ with Large Language Models.
 - [Voiceflow](https://www.voiceflow.com): Professional collaborative visual prompt-chaining tool.
 - [Opik](https://github.com/comet-ml/opik): Evaluate, test, and ship LLM applications across your dev and production lifecycles.
 - [Rhesis AI](https://github.com/rhesis-ai/rhesis): OSS Platform & SDK. Collaborative agent testing for teams.
+- [Rival](https://rival.tips): AI model comparison and multi-model Prompt Lab. Test prompts across 200+ models side-by-side with blind preference voting and open datasets.
 
 ## Prompt Generators
 


### PR DESCRIPTION
Add Rival (https://rival.tips) to the Playgrounds and Alternative UIs section.

Rival is an AI model comparison platform and multi-model Prompt Lab. Users can test prompts across 200+ models side-by-side with blind preference voting, community-driven rankings, and downloadable datasets.