### PR TITLE
Add OpenPaw to Prompt Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ with Large Language Models.
 - [LMQL](https://github.com/eth-sri/lmql): Query language for programming large language models.
 - [OpenPromptStudio](https://moonvy.com/apps/ops/)
 - [BossGPT](https://www.gptboss.com)
+- [OpenPaw](https://github.com/daxaur/openpaw): CLI tool (`npx pawmode`) that generates system prompts (CLAUDE.md + SOUL.md) to turn Claude Code into a personal assistant with 38 skills, memory, and personality.
   
 ## Auto-GPT Related
 


### PR DESCRIPTION
Hey! Adding [OpenPaw](https://github.com/daxaur/openpaw) to the Prompt Generators section.

It's an open-source CLI (`npx pawmode`) that generates system prompts — specifically CLAUDE.md and SOUL.md files that give Claude Code a personality, persistent memory, and 38 skill routers. Basically a prompt generator for turning Claude Code into a personal assistant.

Thanks for the great list!