### PR TITLE
Add flompt to Prompt Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ with Large Language Models.
 - [LMQL](https://github.com/eth-sri/lmql): Query language for programming large language models.
 - [OpenPromptStudio](https://moonvy.com/apps/ops/)
 - [BossGPT](https://www.gptboss.com)
+- [flompt](https://flompt.dev/app): Visual AI prompt builder that decomposes prompts into 12 semantic blocks and recompiles them into optimized XML. Web app, browser extension, and MCP server.
   
 ## Auto-GPT Related
 


### PR DESCRIPTION
Added [flompt](https://github.com/Nyrok/flompt) to the Prompt Generators section.

flompt is a visual AI prompt builder that decomposes any raw prompt into 12 semantic blocks (role, context, objective, constraints, examples, etc.) and recompiles them into optimized XML. Available as a web app, browser extension (Chrome + Firefox), and MCP server. Free and open-source.