### PR TITLE
Add flompt visual prompt builder to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ with Large Language Models.
 - [Opik](https://github.com/comet-ml/opik): Evaluate, test, and ship LLM applications across your dev and production lifecycles.
 - [Rhesis AI](https://github.com/rhesis-ai/rhesis): OSS Platform & SDK. Collaborative agent testing for teams.
 - [Rival](https://rival.tips): AI model comparison and multi-model Prompt Lab. Test prompts across 200+ models side-by-side with blind preference voting and open datasets.
+- [flompt](https://flompt.dev): Free, open-source visual prompt builder that decomposes any prompt into 12 semantic blocks on a React Flow canvas and recompiles them into Claude-optimized XML. Includes a browser extension for ChatGPT/Claude/Gemini and an MCP server for Claude Code agents.
 
 ## Prompt Generators
 


### PR DESCRIPTION
## What

Adds [flompt](https://flompt.dev) to the visual prompt tools section.

## Why

flompt is a free, open-source visual AI prompt builder that:
- Decomposes any prompt into **12 semantic blocks** (role, context, objective, constraints, examples, chain of thought, output format, etc.) on a React Flow canvas
- Recompiles them into Claude-optimized XML following Anthropic's recommended prompt structure
- Ships as a **web app**, a **browser extension** (Chrome + Firefox) that injects into ChatGPT/Claude/Gemini, and an **MCP server** for Claude Code agents

No account required. No paywall. GitHub: https://github.com/Nyrok/flompt