### PR TITLE
Add APort to prompt injection resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ with Large Language Models.
 - [Learn Prompting's Prompt Injection guide](https://learnprompting.org/docs/prompt_hacking/injection): A guide to prompt injections with examples.
 - [Prompt injection: What's the worst that can happen?](https://simonwillison.net/2023/Apr/14/worst-that-can-happen/)
 - [Prompt injections are bad, mkay?](https://greshake.github.io/)
+- [APort](https://aport.io): Agent identity and policy enforcement for AI-agent tool calls, with [guardrail integration examples](https://github.com/aporthq/aport-integrations) for pre-action authorization.
 
 ## ChatGPT Plug-ins
 


### PR DESCRIPTION
Adds APort to the Prompt Injection resources section.

- Links the APort website
- Includes the guardrail integration examples repository
- Describes the identity and policy-enforcement use case for AI-agent tool calls

Validation:
- Verified https://aport.io returns HTTP 200
- Verified https://github.com/aporthq/aport-integrations returns HTTP 200
- Ran `git diff --check`