### PR TITLE
Add 3 production-grade prompt engineering guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Consider giving it a ⭐️ if you like it to show your support!
 - [How OpenAI Parameters Actuallly Work](https://www.prompthub.us/blog/understanding-openai-parameters-how-to-optimize-your-prompts-for-better-outputs): How to use OpenAI's parameters to experiment with prompts and get better outputs.
 - [A Beginner's Guide on Embeddings and Their Impact on Prompts](https://www.prompthub.us/blog/a-beginners-guide-on-embeddings-and-their-impact-on-prompts): A Beginner's Guide on Embeddings and Their Impact on Prompts.
 - [Prompt Engineering for Vision Models](https://www.deeplearning.ai/short-courses/prompt-engineering-for-vision-models/): A beginner's guide to prompting vision models from DeepLearningAI.
+- [Building Effective Agents (Anthropic)](https://www.anthropic.com/research/building-effective-agents): Practical patterns for building reliable LLM-powered agents — from prompt chaining and routing to evaluator-optimizer loops and autonomous agents.
+- [Your AI Product Needs Evals (Hamel Husain)](https://hamel.dev/blog/posts/evals/): The canonical guide on evaluation-driven prompt and product development for LLM applications — test sets, error analysis, and iteration loops.
+- [AI-Native Tech Stack & Architecture (2026)](https://ai-native-agency.com/blog/ai-native-agency-tech-stack): A breakdown of the 5-layer architecture used in production AI builds — model selection, prompt management, retrieval, evaluation, and observability — with tooling recommendations and cost trade-offs.
 
 
 ## Techniques


### PR DESCRIPTION
Hi — thanks for maintaining this list.

Adding three guides that fill a gap I noticed in the **Guides** section: the existing entries lean toward introductory and technique-overview content, but there's thin coverage of production-grade prompt engineering, agent design patterns, and evaluation workflows.

The three additions:

- **[Building Effective Agents (Anthropic)](https://www.anthropic.com/research/building-effective-agents)** — Anthropic's canonical writeup on agent design patterns (prompt chaining, routing, parallelization, evaluator-optimizer loops). Heavily cited in the agent-engineering community.
- **[Your AI Product Needs Evals (Hamel Husain)](https://hamel.dev/blog/posts/evals/)** — The reference guide on evaluation-driven prompt and product development. Practical, with a strong test-set-first methodology.
- **[AI-Native Tech Stack & Architecture (2026)](https://ai-native-agency.com/blog/ai-native-agency-tech-stack)** — Architectural breakdown of the production stack for AI builds, including prompt management, retrieval, and evaluation tooling. Disclosure: I'm associated with the publishing site — included because the 5-layer breakdown (prompt mgmt as a first-class layer) is uncommon in current guides.

Happy to drop any of the three if it doesn't fit. Thanks for the time.