### PR TITLE
feat: Add BestAIFor.com to AI Links Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ with Large Language Models.
 - [KennethanCeyer awesome-llm](https://github.com/KennethanCeyer/awesome-llm)
 - [tensorchord Awesome-LLMOps](https://github.com/tensorchord/Awesome-LLMOps)
 - [Price Per Token](https://pricepertoken.com/): Compare LLM API pricing across 300+ models with benchmarks and cost calculators.
+- [BestAIFor.com](https://bestaifor.com): Curated directory of the best AI tools, organized by use case.
 
 # Contributing
 


### PR DESCRIPTION
Add BestAIFor.com to the AI Links Directories section.

BestAIFor.com is a curated directory of the best AI tools, organized by use case — a natural fit alongside FuturePedia and Theresanaiftorthat already listed in this section.