### PR TITLE
Add Prompt Engineering Techniques to Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Consider giving it a ⭐️ if you like it to show your support!
 
 - [Learn Prompt Engineering](https://learnprompting.org/docs/): Introduction to Prompt Engineering and Prompt Engineering techniques.
 - [Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide): Guides, papers, lecture, notebooks and resources for prompt engineering.
+- [Prompt Engineering Techniques](https://github.com/NirDiamant/Prompt_Engineering): 22 hands-on Jupyter-notebook tutorials, from fundamental prompt structures to advanced techniques like chain-of-thought and self-consistency.
 - [Prompt Engineering 101](https://www.linkedin.com/pulse/prompt-engineering-101-introduction-resources-amatriain): Prompt Engineering guide by Xavi.
 - [Prompt Engineering 101](https://humanloop.com/blog/prompt-engineering-101): Prompt Engineering guide by Raza Habib & Sinan Ozdemir.
 - [Prompt Engineering Guide](https://github.com/SudalaiRajkumar/Talks_Webinars/blob/master/Slides/PromptEngineering_20230208.pdf): Prompt Engineering guide by Sudalai Rajkumar.


### PR DESCRIPTION
Adds [Prompt Engineering Techniques](https://github.com/NirDiamant/Prompt_Engineering) to the Guides section — 22 hands-on Jupyter-notebook tutorials from fundamental prompt structures to advanced techniques (chain-of-thought, self-consistency). Matched the existing format.