### PR TITLE
feat: add TWZRD Agent Intel - agent trust scoring for prompt agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ with Large Language Models.
 
 ## Playgrounds and Alternative UIs
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and wallet identity verification for AI prompt agents on Solana before x402 micropayments. Verify agent wallet identity before accessing paid prompt databases or premium system prompt APIs. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 - [Official OpenAI Playground](https://platform.openai.com/playground)
 - [llm](https://github.com/snwfdhmp/llm): Use any LLM from the command line, easily.
 - [Nat.Dev](https://nat.dev): Multiple Chat AI Playground & Comparer.


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Playgrounds and Alternative UIs section.

TWZRD Agent Intel provides trust scoring for AI prompt agents operating on Solana. When prompt agents access paid prompt databases, premium system prompt APIs, or other paid services via x402 micropayments, the service needs to verify the caller agent's wallet identity and reputation before granting access.

This fits the prompt engineering toolchain as infrastructure for agent-to-agent trust when prompt agents interact with paid resources.

**Tools:**
- `score_agent` — reputation score for an agent wallet (free)
- `preflight_check` — pre-payment risk check (free)
- `get_trust_receipt` — signed trust receipt (paid x402 micropayment)

Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
Service: https://intel.twzrd.xyz