### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ with Large Language Models.
 - [Opik](https://github.com/comet-ml/opik): Evaluate, test, and ship LLM applications across your dev and production lifecycles.
 - [Rhesis AI](https://github.com/rhesis-ai/rhesis): OSS Platform & SDK. Collaborative agent testing for teams.
 - [Rival](https://rival.tips): AI model comparison and multi-model Prompt Lab. Test prompts across 200+ models side-by-side with blind preference voting and open datasets.
+- [Future AGI](https://github.com/future-agi/future-agi): Open-source platform to simulate, evaluate, trace, guardrail, route, and optimize LLM and AI agent apps in one feedback loop, so agents don't just get monitored, they self-improve. Self-hostable. Apache-2.0.
 
 ## Prompt Generators
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the **Playgrounds and Alternative UIs** section.

[Future AGI](https://github.com/future-agi/future-agi) is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.