### PR TITLE
Add XCBot AI image prompt library

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ with Large Language Models.
 - [The Ultimate 5 ChatGPT Prompts](https://ngmi.gumroad.com/l/nobsprompts): Simplify Your AI Experience.
 - [The Prompt Index](https://www.thepromptindex.com/): A vast collection of carefully curated prompts, stimulating imagination and fueling creative endeavours.
 - [PromptDen](https://promptden.com): A growing list of thousands of prompts for both text and image generation. Free to explore, add your own, save your favorites and even create a profile page for prompt engineering.
+- [XCBot AI image prompt library](https://xcbot.cyou/prompts/): Searchable public AI image prompt examples with preview, one-click copy, and source links where available.
 - [God Tier Prompts](https://www.godtierprompts.com): Discover the best prompts. A community-driven leaderboard where the best prompts rise to the top.
 
 ## Papers


### PR DESCRIPTION
Adds XCBot under Prompt Collections. It is a searchable public AI image prompt reference with preview, one-click copy, and source links where available.\n\nXCBot is a resource index, not a model provider. External source links and model names can change over time.