### PR TITLE
Add Omni-Rewriter to Prompt Generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ with Large Language Models.
 - [PromptPerfect](https://promptperfect.jina.ai/): Prompt optimizer.
 - [Hero GPT](https://hero.page/ai-prompts): AI Prompt Generator.
 - [TubePrompter](https://tubeprompter.com): Converts YouTube, TikTok, and Instagram videos into AI-ready prompts for Sora, Midjourney, and Runway using computer vision analysis.
+- [Omni-Rewriter](https://github.com/WayneJin0918/Omni-Rewriter): Open agentic prompt-expansion harness for image/video generators (schema + deterministic validation + bounded repair; expand ≠ generate).
 - [LMQL](https://github.com/eth-sri/lmql): Query language for programming large language models.
 - [OpenPromptStudio](https://moonvy.com/apps/ops/)
 - [BossGPT](https://www.gptboss.com)


### PR DESCRIPTION
## Summary
Add [Omni-Rewriter](https://github.com/WayneJin0918/Omni-Rewriter) — an open agentic **prompt-expansion harness** for image/video generation.

- Schema → Writer LM draft → deterministic validation → bounded repair → dialect render
- Profiles include H3 / Seedance / Seedream / Qwen-Image
- Explicitly separates **expand ≠ generate**
- Apache-2.0 · Demo: https://waynejin0918.github.io/Omni-Rewriter/

## Notes
Happy to adjust section placement or wording if needed. Thanks for maintaining this list!

Made with [Cursor](https://cursor.com)